### PR TITLE
Revamp part two: Switch to `bgp.tools`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sopel-asn
 
-ASN lookup plugin for Sopel IRC bots
+ASN (and MAC address) lookup plugin for Sopel IRC bots
 
 ## Installing
 
@@ -12,39 +12,35 @@ $ pip install sopel-asn
 
 ## Using
 
-**[IPv4, IPv6]** Origin lookup — Find what ASN an IP belongs to:
+Origin lookup — Find what ASN an IP belongs to:
 
 ```
 <dgw> .asn 208.67.222.222
-<Sopel> [ASN] AS36692 | 208.67.222.0/24 | US | Registered at arin on 2006-06-06
+<Sopel> [ASN] 208.67.222.0/24 | AS36692 | Cisco OpenDNS, LLC | US | ARIN |
+        0001-01-01 | more info: https://bgp.tools/as/36692
 
 <dgw> .asn 2001:4860:b002::68
-<Sopel> [ASN] AS15169 | 2001:4860::/32 | US | Registered at arin on 2005-03-14
+<Sopel> [ASN] 2001:4860::/32 | AS15169 | Google LLC | US | ARIN | 2005-03-14 |
+        more info: https://bgp.tools/as/15169
 ```
 
-**[ASN]** AS info — Find the name of an ASN's registrant:
+AS info — Find the name of an ASN's registrant:
 
 ```
 <dgw> .asn 15169
-<Sopel> [ASN] AS15169 | GOOGLE, US | US | Registered at arin on 2000-03-30
+<Sopel> [ASN] AS15169 | Google LLC | US | ARIN | 2000-03-30 | more info:
+        https://bgp.tools/as/15169
 ```
 
-**[IPv4]** Peer lookup — Find other BGP peers of an IP address:
+MAC address info — Find the vendor name assigned to a MAC address:
 
 ```
-<dgw> .asnp 1.1.1.1
-<Sopel> [ASN] 1.1.1.0/24 | AU | Registered at apnic on 2011-08-11 | Peer ASNs:
-        174, 2914, 3257, 6461, 6939, 13335, 23352
-
-# Note: BGP peer lookup is not currently supported for IPv6 addresses.
-<dgw> .asnpeers 2001:4860:b002::68
-<Sopel> dgw: 2001:4860:b002::68 is not a valid IPv4 address.
+<dgw> .mac 00-1a-2b-3c-4d-5e
+<Sopel> [ASN] MAC 00:1A:2B:3C:4D:5E is registered to Ayecom Technology Co., Ltd..
 ```
 
 ## Background
 
-This plugin performs network lookups using Team Cymru's DNS interface, as
-documented at https://www.team-cymru.com/ip-asn-mapping
-
-All data provided is best-effort, and not all lookup types are supported (e.g.
-IPv6 BGP peers, as noted above).
+This plugin performs network lookups via [bgp.tools](https://bgp.tools/) using
+the whois protocol, as documented at https://bgp.tools/kb/api. All data provided
+is best-effort; allocation dates are particularly flaky (often `0001-01-01`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ readme = { file=["README.md", "NEWS"], content-type="text/markdown" }
 [project]
 name = "sopel-asn"
 version = "0.1.0"
-description = "ASN lookup plugin for Sopel IRC bots"
+description = "ASN (and MAC address) lookup plugin for Sopel IRC bots"
 
 authors = [
   { name="dgw", email="dgw@technobabbl.es" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ keywords = [
 requires-python = ">=3.8, <4"
 dependencies = [
   "sopel>=8.0",
-  "dnspython~=2.0",
 ]
 
 [project.urls]

--- a/sopel_asn/plugin.py
+++ b/sopel_asn/plugin.py
@@ -8,18 +8,15 @@ Licensed under the Eiffel Forum License 2.
 """
 from __future__ import annotations
 
-import dns.resolver
-
 from sopel import plugin
 
-from . import util
+from .util import ASRecord, MACRecord
 
 
 PREFIX = plugin.output_prefix('[ASN] ')
 
 
-@plugin.commands('asn', 'asnp', 'asnpeers')
-@plugin.example('.asnp 198.6.1.65', user_help=True)
+@plugin.commands('asn')
 @plugin.example('.asn 208.67.222.222', user_help=True)
 @plugin.example('.asn AS23028', user_help=True)
 @PREFIX
@@ -27,49 +24,48 @@ PREFIX = plugin.output_prefix('[ASN] ')
     user=30,
     message="Please wait {time_left} before attempting another ASN lookup."
 )
-def asn_commands(bot, trigger):
+def asn_command(bot, trigger):
     """Look up ASN (Autonomous System Number) and routing information.
 
-    All commands require an IP address or AS number (in `ASxxx` format) as the
-    first & only argument.
+    Requires an IP address or AS number (in `ASxxx` format) as the first (and
+    only) argument.
     """
     if not (arg := trigger.group(3)):
         bot.reply("Please provide an IP address or ASN.")
         return plugin.NOLIMIT
 
-    mode = 'asn'  # default mode
-    cmd = trigger.group(1).lower()
-    if cmd in ('asnp', 'asnpeers'):
-        mode = 'peers'
-
     try:
-        lookup = util.get_peer_lookup(arg) if mode == 'peers' else util.get_lookup(arg)
+        record: ASRecord = ASRecord.from_free_query(arg)
     except ValueError as e:
         bot.reply(str(e))
         return plugin.NOLIMIT
 
-    if '.origin' in lookup:
-        mode = 'origin'
+    bot.say(
+        str(record),
+        trailing=' | more info: https://bgp.tools/as/' + record.asn,
+    )
+
+
+@plugin.command('mac')
+@plugin.example('.mac 00:1A:2B:3C:4D:5E', user_help=True)
+@PREFIX
+@plugin.rate(
+    user=30,
+    message="Please wait {time_left} before attempting another MAC lookup.",
+)
+def mac_command(bot, trigger):
+    """Look up MAC address vendor information.
+
+    Requires a MAC address as the first (and only) argument.
+    """
+    if not (arg := trigger.group(3)):
+        bot.reply("Please provide a MAC address.")
+        return plugin.NOLIMIT
 
     try:
-        answers = dns.resolver.resolve(lookup, 'TXT')
-    except dns.exception.SyntaxError:
-        bot.reply("That IP address doesn't seem to be valid.")
+        record: MACRecord = MACRecord.from_mac(arg)
+    except ValueError as e:
+        bot.reply(str(e))
         return plugin.NOLIMIT
-    except dns.exception.Timeout:
-        bot.say("Lookup timed out for {}.".format(arg))
-        return plugin.NOLIMIT
-    except dns.resolver.NoNameservers:
-        bot.say("Lookup attempted, but no nameservers were available.")
-        return plugin.NOLIMIT
-    except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
-        bot.say("No records found for {}.".format(arg))
-        return  # do rate-limit, since query succeeded
 
-    if len(answers) > 0:
-        for rdata in answers:
-            bot.say(util.format_record(rdata.to_text(), mode))
-            return
-    else:
-        bot.say("Did not find any records for {}.".format(arg))
-        return
+    bot.say(f"MAC {record.mac} is registered to {record.vendor}.")

--- a/sopel_asn/util.py
+++ b/sopel_asn/util.py
@@ -2,122 +2,189 @@
 from __future__ import annotations
 
 import ipaddress
+import re
+import socket
+
+from sopel.tools import get_logger
 
 
-ENDPOINTS = {
-    'origin': 'origin.asn.cymru.com',
-    'origin6': 'origin6.asn.cymru.com',
-    'peers': 'peer.asn.cymru.com',
-    # there is no peer6 interface, as far as I can tell
-    # queries with both nibbles and bytes return nothing
-    'asn': 'asn.cymru.com',
-}
+LOGGER = get_logger('asn.util')
 
 
-def get_lookup(arg: str | ipaddress.IPv4Address | ipaddress.IPv6Address) -> str:
-    """Get the appropriate lookup string for an IP address or AS number.
+class ASRecord:
+    """An object representing an ASN record from bgp.tools."""
+    def __init__(self, data: dict):
+        self._data = data
 
-    :param arg: An IP address (as a string or ``ipaddress`` object) or AS number
-                (as a string, in ``ASxxx`` format).
-    :return: The lookup string to use for querying Cymru's DNS service.
+    @classmethod
+    def from_string(cls, data: str) -> ASRecord:
+        """Create an ASRecord from a bgp.tools whois response string."""
+        return cls(parse_asn_whois(data))
 
-    :raise ValueError: If the input is not a valid IP address or AS number.
-    """
-    if isinstance(arg, (ipaddress.IPv4Address, ipaddress.IPv6Address)):
-        ip = arg
-    else:
-        try:
-            ip = ipaddress.ip_address(arg)
-        except ValueError:
-            # not an IP address; check if it's an AS number
-            arg = arg.upper()  # ensure "AS" prefix is uppercase, if present
-            if not arg.startswith('AS'):
-                arg = 'AS' + arg
-            if not arg[2:].isdigit():
-                raise ValueError(f"{arg} is not a valid IP address or AS number.")
+    @classmethod
+    def from_asn(cls, asn: str) -> ASRecord:
+        """Create an ASRecord by querying bgp.tools for the given ASN."""
+        asn = asn.upper()  # ensure "AS" prefix is uppercase, if present
+        if not asn.startswith('AS'):
+            asn = 'AS' + asn
+        if not asn[2:].isdigit():
+            raise ValueError(f"{asn} is not a valid AS number (must be in ASxxx format).")
 
-            return arg + '.' + ENDPOINTS['asn']
+        response = bgp_tools_request(asn)
+        return cls.from_string(response)
 
-    # it's an IP address; convert to the appropriate lookup format
-    if ip.version == 4:
-        return '.'.join(
-            reversed(ip.exploded.split('.'))
-        ) + '.' + ENDPOINTS['origin']
-    elif ip.version == 6:
-        nibbles = list(ip.exploded.replace(':', ''))
-        while nibbles[-1] == '0' and nibbles[-2] == '0':
-            nibbles.pop()
-            nibbles.pop()
-        return '.'.join(reversed(nibbles)) + '.' + ENDPOINTS['origin6']
-    else:
-        raise ValueError(f"{arg} is not a valid IP address or AS number.")
+    @classmethod
+    def from_ip(
+        cls,
+        ip: str | ipaddress.IPv4Address | ipaddress.IPv6Address
+    ) -> ASRecord:
+        """Create an ASRecord by querying bgp.tools for the given IP address."""
+        if not isinstance(ip, (ipaddress.IPv4Address, ipaddress.IPv6Address)):
+            try:
+                ip = ipaddress.ip_address(ip)
+            except ValueError:
+                raise ValueError(f"{ip} is not a valid IP address.")
 
+        response = bgp_tools_request(str(ip))
+        return cls.from_string(response)
 
-def get_peer_lookup(arg: str | ipaddress.IPv4Address) -> str:
-    """Get the appropriate lookup string for an IP address for peer queries.
+    @classmethod
+    def from_free_query(cls, query: str) -> ASRecord:
+        """Create an ASRecord by querying bgp.tools for the given free-form query.
 
-    :param arg: An IP address (as a string or ``ipaddress`` object).
-    :return: The lookup string to use for querying Cymru's DNS service for peers.
-    :raise ValueError: If the input is not a valid IPv4 address.
+        The query may be an IP address or AS number (in `ASxxx` format).
+        """
+        query = query.upper().strip()
+        if query.startswith('AS') and query[2:].isdigit():
+            return cls.from_asn(query)
+        elif query.isdigit():
+            return cls.from_asn('AS' + query)
+        else:
+            return cls.from_ip(query)
 
-    Note: Cymru does not appear to maintain a lookup service for IPv6 peers.
-    """
-    if isinstance(arg, ipaddress.IPv4Address):
-        ip = arg
-    else:
-        try:
-            ip = ipaddress.ip_address(arg)
-        except ValueError:
-            raise ValueError(f"{arg} is not a valid IPv4 address.")
-        if ip.version != 4:
-            raise ValueError(f"{arg} is not a valid IPv4 address.")
+    @property
+    def asn(self) -> str:
+        """The AS number."""
+        return self._data.get('as')
 
-    return '.'.join(
-        reversed(ip.exploded.split('.'))
-    ) + '.' + ENDPOINTS['peers']
+    @property
+    def name(self) -> str:
+        """The AS name."""
+        return self._data.get('as_name')
 
+    @property
+    def prefix(self) -> str:
+        """The BGP prefix."""
+        return self._data.get('bgp_prefix')
 
-def format_record(record: str, mode: str) -> str:
-    """Format a DNS record for display."""
-    record = record.strip('"')
-    parts = [part.strip() for part in record.split(' | ')]
+    @property
+    def country(self) -> str:
+        """The country code."""
+        return self._data.get('cc')
 
-    if mode == 'asn':
-        # the ASN record fields are:
-        # number | country_code | registry | registration_date | AS_name
+    @property
+    def registry(self) -> str:
+        """The allocating registry."""
+        return self._data.get('registry')
+
+    @property
+    def allocation_date(self) -> str:
+        """The allocation date."""
+        return self._data.get('allocated')
+
+    def __repr__(self) -> str:
+        return f"<{self._data.get('as name', 'Unknown AS')} ({self.asn})>"
+
+    def __str__(self) -> str:
+        """Format the ASRecord for display."""
+        prefix = f"{self.prefix} | " if self.prefix else ''
         return (
-            "AS{number} | {name} | {country} | Registered at {registry} on {regdate}"
-        ).format(
-            number=parts[0],
-            name=parts[4],
-            country=parts[1],
-            registry=parts[2],
-            regdate=parts[3],
+            f"{prefix}AS{self.asn} | {self.name} | {self.country} | "
+            f"{self.registry} | {self.allocation_date}"
         )
-    elif mode == 'origin':
-        # origin record fields are:
-        # number | prefix | country_code | registry | registration_date
-        return (
-            "AS{number} | {prefix} | {country} | Registered at {registry} on {regdate}"
-        ).format(
-            number=parts[0],
-            prefix=parts[1],
-            country=parts[2],
-            registry=parts[3],
-            regdate=parts[4],
-        )
-    elif mode == 'peers':
-        # peer record fields are:
-        # peer_ASNs (space separated) | prefix | country_code | registry | registration_date
-        return (
-            "{prefix} | {country} | Registered at {registry} on {regdate} | Peer ASNs: {peers}"
-        ).format(
-            prefix=parts[1],
-            peers=', '.join(parts[0].split()),
-            country=parts[2],
-            registry=parts[3],
-            regdate=parts[4],
-        )
+
+
+class MACRecord:
+    """An object representing a MAC address record from bgp.tools."""
+    def __init__(self, mac: str, data: dict):
+        self._data = data
+        self._mac = mac.upper().replace('-', ':')
+
+    @classmethod
+    def from_string(cls, data: str, mac: str = "::") -> MACRecord:
+        """Create a MACRecord from a bgp.tools whois response string.
+
+        The `mac` parameter is optional, but recommended, as without it the
+        `vendor` has no context.
+        """
+        return cls(mac, parse_mac_whois(data))
+
+    @classmethod
+    def from_mac(cls, mac: str) -> MACRecord:
+        """Create a MACRecord by querying bgp.tools for the given MAC address."""
+        mac = mac.upper().replace('-', ':')
+        if not re.match(r'^[0-9A-F]{2}(:[0-9A-F]{2}){5}$', mac):
+            raise ValueError(f"{mac} is not a valid MAC address (must be in XX:XX:XX:XX:XX:XX format).")
+
+        response = bgp_tools_request(mac)
+        return cls.from_string(response, mac)
+
+    @property
+    def mac(self) -> str:
+        """The MAC address."""
+        return self._mac
+
+    @property
+    def vendor(self) -> str:
+        """The vendor name."""
+        return self._data.get('vendor')
+
+    def __repr__(self) -> str:
+        return f"<{self.mac} ({self.vendor})>"
+
+    def __str__(self) -> str:
+        """Format the MACRecord for display."""
+        return f"{self.mac} | {self.vendor}"
+
+
+# `bgp_tools_request()` is a modified version of `whois_request()` from python-whois (WTFPL)
+# https://github.com/joepie91/python-whois/blob/7b0ddf755b3d706860d5d8cb80c598fd854a48ca/pythonwhois/net.py#L84-L94
+def bgp_tools_request(query: str) -> str:
+    """Make a request to bgp.tools' whois service."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.connect(("bgp.tools", 43))
+    sock.send(("%s\r\n" % query).encode("utf-8"))
+    buff = b""
+    while True:
+        data = sock.recv(1024)
+        if len(data) == 0:
+            break
+        buff += data
+    return buff.decode("utf-8")
+
+
+def parse_asn_whois(response: str) -> dict:
+    """Parse a bgp.tools ASN/IP whois response string into a dictionary."""
+    try:
+        fields, data = response.splitlines()
+    except ValueError:
+        LOGGER.warning("Unexpected bgp.tools response format:\n%r", response)
+        raise ValueError("Unexpected bgp.tools response format")
+
+    field_names = [field.strip().lower().replace(' ', '_') for field in fields.split('|')]
+    field_values = [value.strip() for value in data.split('|')]
+
+    if len(field_names) != len(field_values):
+        LOGGER.warning("Mismatched field count in bgp.tools response:\n%r", response)
+        raise ValueError("Mismatched field count in bgp.tools response")
+
+    return dict(zip(field_names, field_values))
+
+
+def parse_mac_whois(response: str) -> dict:
+    """Parse a MAC address lookup response from bgp.tools into a dictionary."""
+    if response.startswith("Vendor:\t"):
+        return {'vendor': response.split('\t', 1)[1].strip()}
     else:
-        # fallback to the raw record for unrecognized modes
-        return record
+        LOGGER.warning("Unexpected MAC address response format:\n%r", response)
+        raise ValueError("Unexpected MAC address response format")


### PR DESCRIPTION
[bgp.tools](https://bgp.tools/) offers lookups over WHOIS, which seem simpler than Team Cymru's DNS-based solution.

MAC address vendor lookups are also supported, so there is a new `.mac` command for that.

Retired `.asnp` for peer lookup because it was unreliable, and bgp.tools seems not to offer an equivalent.